### PR TITLE
fix: broken pipe after cleanup process

### DIFF
--- a/broadlink-thermostat.py
+++ b/broadlink-thermostat.py
@@ -222,16 +222,29 @@ def main():
             for idx, j in enumerate(jobs):
                 if not j.is_alive():
                     try:
+                        print "Killing job."
                         j.join()
                     except:
+                        print "Error killing job."
                         pass
                     try:
+                        print "Deleting pipe from pipes array"
+                        for idy, (ID, pipe) in enumerate(pipes):
+                            if ID==founddevices[j.pid]:
+                                del pipes[idy]
+                    except:
+                        print "Error deleting pipe from pipes array"
+                    try:
+                        print "Deleting device from founddevices array."
                         del founddevices[j.pid]
                     except:
+                        print "Error deleting device from founddevices array."
                         pass
                     try:
+                        print "Deleting job from jobs array."
                         del jobs[idx]
                     except:
+                        print "Error deleting job from jobs array."
                         pass
             print "broadlink discover"
             devices = broadlink.discover(timeout=conf.get('lookup_timeout', 5))


### PR DESCRIPTION
the cleanup process didn't clean up the pipe from the pipes array that
contains the pipe to the subprocess of the thermostat. This resulted in
a "broken pipe" error as it was sending commands to the old pipe after
rediscovering the device.

Issue: Closes #10 